### PR TITLE
upgraded to terraform 0.12 syntax using the upgrade tool.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+export TERRAFORM_VERSION = 0.12.5
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md

--- a/main.tf
+++ b/main.tf
@@ -1,84 +1,111 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_vpc_peering_connection" "default" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id      = "${join("", data.aws_vpc.requestor.*.id)}"
-  peer_vpc_id = "${join("", data.aws_vpc.acceptor.*.id)}"
+  count       = var.enabled == "true" ? 1 : 0
+  vpc_id      = join("", data.aws_vpc.requestor.*.id)
+  peer_vpc_id = join("", data.aws_vpc.acceptor.*.id)
 
-  auto_accept = "${var.auto_accept}"
+  auto_accept = var.auto_accept
 
   accepter {
-    allow_remote_vpc_dns_resolution = "${var.acceptor_allow_remote_vpc_dns_resolution}"
+    allow_remote_vpc_dns_resolution = var.acceptor_allow_remote_vpc_dns_resolution
   }
 
   requester {
-    allow_remote_vpc_dns_resolution = "${var.requestor_allow_remote_vpc_dns_resolution}"
+    allow_remote_vpc_dns_resolution = var.requestor_allow_remote_vpc_dns_resolution
   }
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 }
 
 # Lookup requestor VPC so that we can reference the CIDR
 data "aws_vpc" "requestor" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  id    = "${var.requestor_vpc_id}"
-  tags  = "${var.requestor_vpc_tags}"
+  count = var.enabled == "true" ? 1 : 0
+  id    = var.requestor_vpc_id
+  tags  = var.requestor_vpc_tags
 }
 
 # Lookup requestor route tables
 data "aws_route_table" "requestor" {
-  count     = "${var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.requestor.ids))) : 0}"
-  subnet_id = "${element(distinct(sort(data.aws_subnet_ids.requestor.ids)), count.index)}"
+  count = var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.requestor[0].ids))) : 0
+  subnet_id = element(
+    distinct(sort(data.aws_subnet_ids.requestor[0].ids)),
+    count.index,
+  )
 }
 
 # Lookup requestor subnets
 data "aws_subnet_ids" "requestor" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id = "${data.aws_vpc.requestor.id}"
+  count  = var.enabled == "true" ? 1 : 0
+  vpc_id = data.aws_vpc.requestor[0].id
 }
 
 # Lookup acceptor VPC so that we can reference the CIDR
 data "aws_vpc" "acceptor" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  id    = "${var.acceptor_vpc_id}"
-  tags  = "${var.acceptor_vpc_tags}"
+  count = var.enabled == "true" ? 1 : 0
+  id    = var.acceptor_vpc_id
+  tags  = var.acceptor_vpc_tags
 }
 
 # Lookup acceptor subnets
 data "aws_subnet_ids" "acceptor" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id = "${data.aws_vpc.acceptor.id}"
+  count  = var.enabled == "true" ? 1 : 0
+  vpc_id = data.aws_vpc.acceptor[0].id
 }
 
 # Lookup acceptor route tables
 data "aws_route_table" "acceptor" {
-  count     = "${var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.acceptor.ids))) : 0}"
-  subnet_id = "${element(distinct(sort(data.aws_subnet_ids.acceptor.ids)), count.index)}"
+  count = var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.acceptor[0].ids))) : 0
+  subnet_id = element(
+    distinct(sort(data.aws_subnet_ids.acceptor[0].ids)),
+    count.index,
+  )
 }
 
 # Create routes from requestor to acceptor
 resource "aws_route" "requestor" {
-  count                     = "${var.enabled == "true" ? length(distinct(sort(data.aws_route_table.requestor.*.route_table_id))) * length(data.aws_vpc.acceptor.cidr_block_associations) : 0}"
-  route_table_id            = "${element(distinct(sort(data.aws_route_table.requestor.*.route_table_id)), (ceil(count.index / (length(data.aws_vpc.acceptor.cidr_block_associations)))))}"
-  destination_cidr_block    = "${lookup(data.aws_vpc.acceptor.cidr_block_associations[count.index % (length(data.aws_vpc.acceptor.cidr_block_associations))], "cidr_block")}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.default.id}"
-  depends_on                = ["data.aws_route_table.requestor", "aws_vpc_peering_connection.default"]
+  count = var.enabled == "true" ? length(
+    distinct(sort(data.aws_route_table.requestor.*.route_table_id)),
+  ) * length(data.aws_vpc.acceptor[0].cidr_block_associations) : 0
+  route_table_id = element(
+    distinct(sort(data.aws_route_table.requestor.*.route_table_id)),
+    ceil(
+      count.index / length(data.aws_vpc.acceptor[0].cidr_block_associations),
+    ),
+  )
+  destination_cidr_block    = data.aws_vpc.acceptor.0.cidr_block_associations[count.index % length(data.aws_vpc.acceptor[0].cidr_block_associations)]["cidr_block"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.default[0].id
+  depends_on = [
+    data.aws_route_table.requestor,
+    aws_vpc_peering_connection.default,
+  ]
 }
 
 # Create routes from acceptor to requestor
 resource "aws_route" "acceptor" {
-  count                     = "${var.enabled == "true" ? length(distinct(sort(data.aws_route_table.acceptor.*.route_table_id))) * length(data.aws_vpc.requestor.cidr_block_associations) : 0}"
-  route_table_id            = "${element(distinct(sort(data.aws_route_table.acceptor.*.route_table_id)), ceil(count.index / (length(data.aws_vpc.requestor.cidr_block_associations))))}"
-  destination_cidr_block    = "${lookup(data.aws_vpc.requestor.cidr_block_associations[count.index % (length(data.aws_vpc.requestor.cidr_block_associations))], "cidr_block")}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.default.id}"
-  depends_on                = ["data.aws_route_table.acceptor", "aws_vpc_peering_connection.default"]
+  count = var.enabled == "true" ? length(
+    distinct(sort(data.aws_route_table.acceptor.*.route_table_id)),
+  ) * length(data.aws_vpc.requestor[0].cidr_block_associations) : 0
+  route_table_id = element(
+    distinct(sort(data.aws_route_table.acceptor.*.route_table_id)),
+    ceil(
+      count.index / length(data.aws_vpc.requestor[0].cidr_block_associations),
+    ),
+  )
+  destination_cidr_block    = data.aws_vpc.requestor.0.cidr_block_associations[count.index % length(data.aws_vpc.requestor[0].cidr_block_associations)]["cidr_block"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.default[0].id
+  depends_on = [
+    data.aws_route_table.acceptor,
+    aws_vpc_peering_connection.default,
+  ]
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,10 @@
 output "connection_id" {
-  value       = "${join("", aws_vpc_peering_connection.default.*.id)}"
+  value       = join("", aws_vpc_peering_connection.default.*.id)
   description = "VPC peering connection ID"
 }
 
 output "accept_status" {
-  value       = "${join("", aws_vpc_peering_connection.default.*.accept_status)}"
+  value       = join("", aws_vpc_peering_connection.default.*.accept_status)
   description = "The status of the VPC peering connection request"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -4,25 +4,25 @@ variable "enabled" {
 }
 
 variable "requestor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Requestor VPC ID"
   default     = ""
 }
 
 variable "requestor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Requestor VPC tags"
   default     = {}
 }
 
 variable "acceptor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Acceptor VPC ID"
   default     = ""
 }
 
 variable "acceptor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Acceptor VPC tags"
   default     = {}
 }
@@ -44,33 +44,34 @@ variable "requestor_allow_remote_vpc_dns_resolution" {
 
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "name" {
   description = "Name  (e.g. `app` or `cluster`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This PR includes the changes generated by the TF 0.12 upgrade tool. The dependent null-label module also has been upgraded to the latest version that has TF 0.12 changes. 

Notes: After upgrading to use this module, the label's null resource was destroyed without impact to the peering.

Please review and let me know your comments.
