### PR TITLE
Update for TF v0.12, and remove dependency on subnet ids #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SHELL := /bin/bash
+export TERRAFORM_VERSION = 0.12.5
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ data "aws_vpc" "requestor" {
 # Lookup requestor route tables
 data "aws_route_tables" "requestor" {
   count  = var.enabled ? 1 : 0
-  vpc_id = data.aws_vpc.acceptor.0.id
+  vpc_id = data.aws_vpc.requestor.0.id
 }
 
 # Lookup acceptor VPC so that we can reference the CIDR

--- a/main.tf
+++ b/main.tf
@@ -1,84 +1,92 @@
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
-  enabled    = "${var.enabled}"
-  namespace  = "${var.namespace}"
-  name       = "${var.name}"
-  stage      = "${var.stage}"
-  delimiter  = "${var.delimiter}"
-  attributes = "${var.attributes}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.15.0"
+  enabled    = var.enabled
+  namespace  = var.namespace
+  name       = var.name
+  stage      = var.stage
+  delimiter  = var.delimiter
+  attributes = var.attributes
+  tags       = var.tags
 }
 
 resource "aws_vpc_peering_connection" "default" {
-  count       = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id      = "${join("", data.aws_vpc.requestor.*.id)}"
-  peer_vpc_id = "${join("", data.aws_vpc.acceptor.*.id)}"
+  count       = var.enabled ? 1 : 0
+  vpc_id      = join("", data.aws_vpc.requestor.*.id)
+  peer_vpc_id = join("", data.aws_vpc.acceptor.*.id)
 
-  auto_accept = "${var.auto_accept}"
+  auto_accept = var.auto_accept
 
   accepter {
-    allow_remote_vpc_dns_resolution = "${var.acceptor_allow_remote_vpc_dns_resolution}"
+    allow_remote_vpc_dns_resolution = var.acceptor_allow_remote_vpc_dns_resolution
   }
 
   requester {
-    allow_remote_vpc_dns_resolution = "${var.requestor_allow_remote_vpc_dns_resolution}"
+    allow_remote_vpc_dns_resolution = var.requestor_allow_remote_vpc_dns_resolution
   }
 
-  tags = "${module.label.tags}"
+  tags = module.label.tags
 }
 
 # Lookup requestor VPC so that we can reference the CIDR
 data "aws_vpc" "requestor" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  id    = "${var.requestor_vpc_id}"
-  tags  = "${var.requestor_vpc_tags}"
+  count = var.enabled ? 1 : 0
+  id    = var.requestor_vpc_id
+  tags  = var.requestor_vpc_tags
 }
 
 # Lookup requestor route tables
-data "aws_route_table" "requestor" {
-  count     = "${var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.requestor.ids))) : 0}"
-  subnet_id = "${element(distinct(sort(data.aws_subnet_ids.requestor.ids)), count.index)}"
-}
-
-# Lookup requestor subnets
-data "aws_subnet_ids" "requestor" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id = "${data.aws_vpc.requestor.id}"
+data "aws_route_tables" "requestor" {
+  count  = var.enabled ? 1 : 0
+  vpc_id = data.aws_vpc.acceptor.0.id
 }
 
 # Lookup acceptor VPC so that we can reference the CIDR
 data "aws_vpc" "acceptor" {
-  count = "${var.enabled == "true" ? 1 : 0}"
-  id    = "${var.acceptor_vpc_id}"
-  tags  = "${var.acceptor_vpc_tags}"
-}
-
-# Lookup acceptor subnets
-data "aws_subnet_ids" "acceptor" {
-  count  = "${var.enabled == "true" ? 1 : 0}"
-  vpc_id = "${data.aws_vpc.acceptor.id}"
+  count = var.enabled ? 1 : 0
+  id    = var.acceptor_vpc_id
+  tags  = var.acceptor_vpc_tags
 }
 
 # Lookup acceptor route tables
-data "aws_route_table" "acceptor" {
-  count     = "${var.enabled == "true" ? length(distinct(sort(data.aws_subnet_ids.acceptor.ids))) : 0}"
-  subnet_id = "${element(distinct(sort(data.aws_subnet_ids.acceptor.ids)), count.index)}"
+data "aws_route_tables" "acceptor" {
+  count  = var.enabled ? 1 : 0
+  vpc_id = data.aws_vpc.acceptor.0.id
 }
 
 # Create routes from requestor to acceptor
 resource "aws_route" "requestor" {
-  count                     = "${var.enabled == "true" ? length(distinct(sort(data.aws_route_table.requestor.*.route_table_id))) * length(data.aws_vpc.acceptor.cidr_block_associations) : 0}"
-  route_table_id            = "${element(distinct(sort(data.aws_route_table.requestor.*.route_table_id)), (ceil(count.index / (length(data.aws_vpc.acceptor.cidr_block_associations)))))}"
-  destination_cidr_block    = "${lookup(data.aws_vpc.acceptor.cidr_block_associations[count.index % (length(data.aws_vpc.acceptor.cidr_block_associations))], "cidr_block")}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.default.id}"
-  depends_on                = ["data.aws_route_table.requestor", "aws_vpc_peering_connection.default"]
+  count = var.enabled ? length(
+    distinct(sort(data.aws_route_tables.requestor.0.ids)),
+  ) * length(data.aws_vpc.acceptor.0.cidr_block_associations) : 0
+  route_table_id = element(
+    distinct(sort(data.aws_route_tables.requestor.0.ids)),
+    ceil(
+      count.index / length(data.aws_vpc.acceptor.0.cidr_block_associations),
+    ),
+  )
+  destination_cidr_block    = data.aws_vpc.acceptor.0.cidr_block_associations[count.index % length(data.aws_vpc.acceptor.0.cidr_block_associations)]["cidr_block"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.default.0.id
+  depends_on = [
+    data.aws_route_tables.requestor,
+    aws_vpc_peering_connection.default,
+  ]
 }
 
 # Create routes from acceptor to requestor
 resource "aws_route" "acceptor" {
-  count                     = "${var.enabled == "true" ? length(distinct(sort(data.aws_route_table.acceptor.*.route_table_id))) * length(data.aws_vpc.requestor.cidr_block_associations) : 0}"
-  route_table_id            = "${element(distinct(sort(data.aws_route_table.acceptor.*.route_table_id)), ceil(count.index / (length(data.aws_vpc.requestor.cidr_block_associations))))}"
-  destination_cidr_block    = "${lookup(data.aws_vpc.requestor.cidr_block_associations[count.index % (length(data.aws_vpc.requestor.cidr_block_associations))], "cidr_block")}"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.default.id}"
-  depends_on                = ["data.aws_route_table.acceptor", "aws_vpc_peering_connection.default"]
+  count = var.enabled ? length(
+    distinct(sort(data.aws_route_tables.acceptor.0.ids)),
+  ) * length(data.aws_vpc.requestor.0.cidr_block_associations) : 0
+  route_table_id = element(
+    distinct(sort(data.aws_route_tables.acceptor.0.ids)),
+    ceil(
+      count.index / length(data.aws_vpc.requestor.0.cidr_block_associations),
+    ),
+  )
+  destination_cidr_block    = data.aws_vpc.requestor.0.cidr_block_associations[count.index % length(data.aws_vpc.requestor.0.cidr_block_associations)]["cidr_block"]
+  vpc_peering_connection_id = aws_vpc_peering_connection.default.0.id
+  depends_on = [
+    data.aws_route_tables.acceptor,
+    aws_vpc_peering_connection.default,
+  ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,73 +4,76 @@ variable "enabled" {
 }
 
 variable "requestor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Requestor VPC ID"
   default     = ""
 }
 
 variable "requestor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Requestor VPC tags"
   default     = {}
 }
 
 variable "acceptor_vpc_id" {
-  type        = "string"
+  type        = string
   description = "Acceptor VPC ID"
   default     = ""
 }
 
 variable "acceptor_vpc_tags" {
-  type        = "map"
+  type        = map(string)
   description = "Acceptor VPC tags"
   default     = {}
 }
 
 variable "auto_accept" {
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Automatically accept the peering (both VPCs need to be in the same AWS account)"
 }
 
 variable "acceptor_allow_remote_vpc_dns_resolution" {
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC"
 }
 
 variable "requestor_allow_remote_vpc_dns_resolution" {
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC"
 }
 
 variable "namespace" {
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  type        = "string"
+  type        = string
 }
 
 variable "stage" {
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  type        = "string"
+  type        = string
 }
 
 variable "name" {
   description = "Name  (e.g. `app` or `cluster`)"
-  type        = "string"
+  type        = string
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `stage`, `name`, and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes (e.g. `policy` or `role`)"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. map('BusinessUnit`,`XYZ`)"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
New PR, replacing #15 created by @bkonkle who is no longer able to iterate and test on this.

Original PR message:

> Terraform now has an aws_route_tables data source that allows you to skip the subnet id lookup. In addition, it works around the problem where if there are one or more subnets that are (non-explictly) associated with the Main route table, TF throws this error:
> `Your query returned no results. Please change your search criteria and try again.`

There seem to be some possible workflows that can cause `"count" ... cannot be determined
until apply` errors. 

Tested creating/removing the peering with both VPCs already present and that worked fine. I doubt if possible count-related issues are related to the TF 0.12 upgrade.