### PR TITLE
Allow filtering route tables using tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
+| acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
@@ -156,6 +157,7 @@ Available targets:
 | name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
+| requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
+| acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
@@ -30,6 +31,7 @@
 | name | Solution name, e.g. 'app' or 'cluster' | `string` | n/a | yes |
 | namespace | Namespace, which could be your organization name, e.g. 'eg' or 'cp' | `string` | `""` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
+| requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', or 'test' | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -50,11 +50,13 @@ data "aws_vpc" "acceptor" {
 data "aws_route_tables" "requestor" {
   count  = var.enabled ? 1 : 0
   vpc_id = join("", data.aws_vpc.requestor.*.id)
+  tags   = var.requestor_route_table_tags
 }
 
 data "aws_route_tables" "acceptor" {
   count  = var.enabled ? 1 : 0
   vpc_id = join("", data.aws_vpc.acceptor.*.id)
+  tags   = var.acceptor_route_table_tags
 }
 
 # Create routes from requestor to acceptor

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,12 @@ variable "requestor_vpc_tags" {
   default     = {}
 }
 
+variable "requestor_route_table_tags" {
+  type        = map(string)
+  description = "Only add peer routes to requestor VPC route tables matching these tags"
+  default     = {}
+}
+
 variable "acceptor_vpc_id" {
   type        = string
   description = "Acceptor VPC ID"
@@ -60,6 +66,12 @@ variable "acceptor_vpc_id" {
 variable "acceptor_vpc_tags" {
   type        = map(string)
   description = "Acceptor VPC tags"
+  default     = {}
+}
+
+variable "acceptor_route_table_tags" {
+  type        = map(string)
+  description = "Only add peer routes to acceptor VPC route tables matching these tags"
   default     = {}
 }
 


### PR DESCRIPTION
## what
* Caller can supply tags for both the acceptor and requestor VPCs, and if present, peering routes will only be added to route tables matching those tags.
* Default behavior is unchanged.

## why
Support environments with private subnets that shouldn't be allowed to communicate with peer VPCs.
