### PR TITLE
Allow filtering route tables using filters on aws_route_tables data resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
+| acceptor\_route\_table\_filters | Only add peer routes to acceptor VPC route tables matching these filters. For more details, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables#filter | `list(any)` | `[]` | no |
 | acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
@@ -176,6 +177,7 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
+| requestor\_route\_table\_filters | Only add peer routes to requestor VPC route tables matching these filters. For more details, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables#filter | `list(any)` | `[]` | no |
 | requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
+| acceptor\_route\_table\_filters | Only add peer routes to acceptor VPC route tables matching these filters. For more details, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables#filter | `list(any)` | `[]` | no |
 | acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
@@ -37,6 +38,7 @@
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
+| requestor\_route\_table\_filters | Only add peer routes to requestor VPC route tables matching these filters. For more details, see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables#filter | `list(any)` | `[]` | no |
 | requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -40,12 +40,28 @@ data "aws_route_tables" "requestor" {
   count  = module.this.enabled ? 1 : 0
   vpc_id = join("", data.aws_vpc.requestor.*.id)
   tags   = var.requestor_route_table_tags
+
+  dynamic "filter" {
+    for_each = var.requestor_route_table_filters
+    content {
+      name   = filter.value["name"]
+      values = filter.value["values"]
+    }
+  }
 }
 
 data "aws_route_tables" "acceptor" {
   count  = module.this.enabled ? 1 : 0
   vpc_id = join("", data.aws_vpc.acceptor.*.id)
   tags   = var.acceptor_route_table_tags
+
+  dynamic "filter" {
+    for_each = var.acceptor_route_table_filters
+    content {
+      name   = filter.value["name"]
+      values = filter.value["values"]
+    }
+  }
 }
 
 # Create routes from requestor to acceptor

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "requestor_vpc_tags" {
   default     = {}
 }
 
+variable "requestor_route_table_filters" {
+  type        = list(any)
+  description = "Only add peer routes to requestor VPC route tables matching these filters"
+  default     = []
+}
+
 variable "requestor_route_table_tags" {
   type        = map(string)
   description = "Only add peer routes to requestor VPC route tables matching these tags"
@@ -26,6 +32,12 @@ variable "acceptor_vpc_tags" {
   type        = map(string)
   description = "Acceptor VPC tags"
   default     = {}
+}
+
+variable "acceptor_route_table_filters" {
+  type        = list(any)
+  description = "Only add peer routes to acceptor VPC route tables matching these filters"
+  default     = []
 }
 
 variable "acceptor_route_table_tags" {


### PR DESCRIPTION
## what
* Add support to use the custom filter blocks accepted by the aws_route_tables data resource to select the acceptor and/or requestor route tables that should be updated.
* Default behavior should remain unchanged.

## why
* Support for more complex filtering of the route tables which cannot be achieved by using the tags based filtering. For example, select multiple route tables by their name.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables#filter

