### PR TITLE
minimum required Terraform version bumped to 0.13.0, context.tf updated, readme updated

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -43,3 +43,11 @@ change-template: |
 
 template: |
   $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,16 @@
+# https://docs.mergify.io/conditions.html
+# https://docs.mergify.io/actions.html
 pull_request_rules:
 - name: "approve automated PRs that have passed checks"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "author=cloudpossebot"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   actions:
     review:
       type: "APPROVE"
@@ -15,16 +19,17 @@ pull_request_rules:
 
 - name: "merge automated PRs when approved and tests pass"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   - "#approved-reviews-by>=1"
   - "#changes-requested-reviews-by=0"
   - "#commented-reviews-by=0"
-  - "base=master"
-  - "author=cloudpossebot"
   actions:
     merge:
       method: "squash"
@@ -38,6 +43,7 @@ pull_request_rules:
 - name: "ask to resolve conflict"
   conditions:
   - "conflict"
+  - "-closed"
   actions:
     comment:
       message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,7 +27,7 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
@@ -38,6 +38,8 @@ jobs:
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,86 @@
+name: Auto Format
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    container: cloudposse/build-harness:slim-latest
+    steps:
+    # Checkout the pull request branch
+    #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
+    #   the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains
+    #   a workflow configured to run when push events occur."
+    # However, using a personal access token will cause events to be triggered.
+    # We need that to ensure a status gets posted after the auto-format commit.
+    # We also want to trigger tests if the auto-format made no changes.
+    - uses: actions/checkout@v2
+      if: github.event.pull_request.state == 'open'
+      name: Privileged Checkout
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Check out the PR commit, not the merge commit
+        # Use `ref` instead of `sha` to enable pushing back to `ref`
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Do all the formatting stuff
+    - name: Auto Format
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
+
+    # Commit changes (if any) to the PR branch
+    - name: Commit changes to the PR branch
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      id: commit
+      env:
+        SENDER: ${{ github.event.sender.login }}
+      run: |
+        set -x
+        output=$(git diff --name-only)
+
+        if [ -n "$output" ]; then
+          echo "Changes detected. Pushing to the PR branch"
+          git config --global user.name 'cloudpossebot'
+          git config --global user.email '11232728+cloudpossebot@users.noreply.github.com'
+          git add -A
+          git commit -m "Auto Format"
+          # Prevent looping by not pushing changes in response to changes from cloudpossebot
+          [[ $SENDER ==  "cloudpossebot" ]] || git push
+          # Set status to fail, because the push should trigger another status check,
+          # and we use success to indicate the checks are finished.
+          printf "::set-output name=%s::%s\n" "changed" "true"
+          exit 1
+        else
+          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "No changes detected"
+        fi
+
+    - name: Auto Test
+      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      # match users by ID because logins (user names) are inconsistent,
+      # for example in the REST API Renovate Bot is `renovate[bot]` but
+      # in GraphQL it is just `renovate`, plus there is a non-bot
+      # user `renovate` with ID 1832810.
+      # Mergify bot: 37929162
+      # Renovate bot: 29139614
+      # Cloudpossebot: 11232728
+      # Need to use space separators to prevent "21" from matching "112144"
+      if: >
+        contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
+        && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: cloudposse/actions
+        event-type: test-command
+        client-payload: |-
+          { "slash_command":{"args": {"unnamed": {"all": "all", "arg1": "all"}}},
+             "pull_request": ${{ toJSON(github.event.pull_request) }},
+             "github":{"payload":{"repository": ${{ toJSON(github.event.repository) }},
+                                  "comment": {"id": ""}
+                                 }
+                      }
+          }

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  semver:
+  publish:
     runs-on: ubuntu-latest
     steps:
     # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/README.md
+++ b/README.md
@@ -67,6 +67,25 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 
 
 
+## Security & Compliance [<img src="https://cloudposse.com/wp-content/uploads/2020/11/bridgecrew.svg" width="250" align="right" />](https://bridgecrew.io/)
+
+Security scanning is graciously provided by Bridgecrew. Bridgecrew is the leading fully hosted, cloud-native solution providing continuous Terraform security and compliance.
+
+| Benchmark | Description |
+|--------|---------------|
+| [![Infrastructure Security](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/general)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=INFRASTRUCTURE+SECURITY) | Infrastructure Security Compliance |
+| [![CIS KUBERNETES](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/cis_kubernetes)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=CIS+KUBERNETES+V1.5) | Center for Internet Security, KUBERNETES Compliance |
+| [![CIS AWS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/cis_aws)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=CIS+AWS+V1.2) | Center for Internet Security, AWS Compliance |
+| [![CIS AZURE](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/cis_azure)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=CIS+AZURE+V1.1) | Center for Internet Security, AZURE Compliance |
+| [![PCI-DSS](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/pci)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=PCI-DSS+V3.2) | Payment Card Industry Data Security Standards Compliance |
+| [![NIST-800-53](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/nist)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=NIST-800-53) | National Institute of Standards and Technology Compliance |
+| [![ISO27001](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/iso)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=ISO27001) | Information Security Management System, ISO/IEC 27001 Compliance |
+| [![SOC2](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/soc2)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=SOC2)| Service Organization Control 2 Compliance |
+| [![CIS GCP](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/cis_gcp)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=CIS+GCP+V1.1) | Center for Internet Security, GCP Compliance |
+| [![HIPAA](https://www.bridgecrew.cloud/badges/github/cloudposse/terraform-aws-vpc-peering/hipaa)](https://www.bridgecrew.cloud/link/badge?vcs=github&fullRepo=cloudposse%2Fterraform-aws-vpc-peering&benchmark=HIPAA) | Health Insurance Portability and Accountability Compliance |
+
+
+
 ## Usage
 
 
@@ -142,7 +161,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.0 |
@@ -164,14 +183,16 @@ Available targets:
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_accept | Automatically accept the peering (both VPCs need to be in the same AWS account) | `bool` | `true` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | create\_timeout | VPC peering connection create timeout. For more details, see https://www.terraform.io/docs/configuration/resources.html#operation-timeouts | `string` | `"3m"` | no |
 | delete\_timeout | VPC peering connection delete timeout. For more details, see https://www.terraform.io/docs/configuration/resources.html#operation-timeouts | `string` | `"5m"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
@@ -289,7 +310,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/context.tf
+++ b/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.23.0" // requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -55,6 +54,8 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
+    label_key_case      = string
+    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -69,6 +70,8 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -77,6 +80,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -166,4 +179,33 @@ variable "id_length_limit" {
   EOT
 }
 
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`. 
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.26 |
+| terraform | >= 0.13.0 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | template | >= 2.0 |
@@ -25,14 +25,16 @@
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | auto\_accept | Automatically accept the peering (both VPCs need to be in the same AWS account) | `bool` | `true` | no |
-| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>    label_key_case      = string<br>    label_value_case    = string<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_key_case": null,<br>  "label_order": [],<br>  "label_value_case": null,<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | create\_timeout | VPC peering connection create timeout. For more details, see https://www.terraform.io/docs/configuration/resources.html#operation-timeouts | `string` | `"3m"` | no |
 | delete\_timeout | VPC peering connection delete timeout. For more details, see https://www.terraform.io/docs/configuration/resources.html#operation-timeouts | `string` | `"5m"` | no |
 | delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
+| label\_key\_case | The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.<br>Possible values: `lower`, `title`, `upper`. <br>Default value: `title`. | `string` | `null` | no |
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
+| label\_value\_case | The letter case of output label values (also used in `tags` and `id`).<br>Possible values: `lower`, `title`, `upper` and `none` (no transformation). <br>Default value: `lower`. | `string` | `null` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -18,10 +18,9 @@
 # will be null, and `module.this.delimiter` will be `-` (hyphen).
 #
 
-
 module "this" {
   source  = "cloudposse/label/null"
-  version = "0.22.0" // requires Terraform >= 0.12.26
+  version = "0.23.0" // requires Terraform >= 0.13.0
 
   enabled             = var.enabled
   namespace           = var.namespace
@@ -55,6 +54,8 @@ variable "context" {
     regex_replace_chars = string
     label_order         = list(string)
     id_length_limit     = number
+    label_key_case      = string
+    label_value_case    = string
   })
   default = {
     enabled             = true
@@ -69,6 +70,8 @@ variable "context" {
     regex_replace_chars = null
     label_order         = []
     id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
   }
   description = <<-EOT
     Single object for setting entire context at once.
@@ -77,6 +80,16 @@ variable "context" {
     Individual variable settings (non-null) override settings in context object,
     except for attributes, tags, and additional_tag_map, which are merged.
   EOT
+
+  validation {
+    condition     = var.context["label_key_case"] == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = var.context["label_value_case"] == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
 }
 
 variable "enabled" {
@@ -166,4 +179,33 @@ variable "id_length_limit" {
   EOT
 }
 
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of label keys (`tag` names) (i.e. `name`, `namespace`, `environment`, `stage`, `attributes`) to use in `tags`.
+    Possible values: `lower`, `title`, `upper`. 
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    The letter case of output label values (also used in `tags` and `id`).
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation). 
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
 #### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what
- update context.tf to v0.23.0 
- minimum required Terraform version bumped to 0.13.0 
- readme updated, Bridgecrew compliance badges added

## why
- It allows for setting the letter case of tag names and labels
- we have dropped support for Terraform 0.12
- To be able see and fix the recommendations from Bridgecrew so we can position our modules as standards compliant
