### PR TITLE
feat: optional route tables routes creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
 | acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
+| acceptor\_routes\_create | Whether to add routes for the acceptor VPC to the route tables or not | `bool` | `true` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
@@ -198,6 +199,7 @@ Available targets:
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
 | requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
+| requestor\_routes\_create | Whether to add routes for the requestor VPC to the route tables or not | `bool` | `true` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 |------|-------------|------|---------|:--------:|
 | acceptor\_allow\_remote\_vpc\_dns\_resolution | Allow acceptor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requestor VPC | `bool` | `true` | no |
 | acceptor\_route\_table\_tags | Only add peer routes to acceptor VPC route tables matching these tags | `map(string)` | `{}` | no |
+| acceptor\_routes\_create | Whether to add routes for the acceptor VPC to the route tables or not | `bool` | `true` | no |
 | acceptor\_vpc\_id | Acceptor VPC ID | `string` | `""` | no |
 | acceptor\_vpc\_tags | Acceptor VPC tags | `map(string)` | `{}` | no |
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
@@ -40,6 +41,7 @@
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requestor\_allow\_remote\_vpc\_dns\_resolution | Allow requestor VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the acceptor VPC | `bool` | `true` | no |
 | requestor\_route\_table\_tags | Only add peer routes to requestor VPC route tables matching these tags | `map(string)` | `{}` | no |
+| requestor\_routes\_create | Whether to add routes for the requestor VPC to the route tables or not | `bool` | `true` | no |
 | requestor\_vpc\_id | Requestor VPC ID | `string` | `""` | no |
 | requestor\_vpc\_tags | Requestor VPC tags | `map(string)` | `{}` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ data "aws_route_tables" "acceptor" {
 
 # Create routes from requestor to acceptor
 resource "aws_route" "requestor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.requestor.0.ids))) * length(data.aws_vpc.acceptor.0.cidr_block_associations) : 0
+  count                     = module.this.enabled && var.requestor_routes_create ? length(distinct(sort(data.aws_route_tables.requestor.0.ids))) * length(data.aws_vpc.acceptor.0.cidr_block_associations) : 0
   route_table_id            = element(distinct(sort(data.aws_route_tables.requestor.0.ids)), ceil(count.index / length(data.aws_vpc.acceptor.0.cidr_block_associations)))
   destination_cidr_block    = data.aws_vpc.acceptor.0.cidr_block_associations[count.index % length(data.aws_vpc.acceptor.0.cidr_block_associations)]["cidr_block"]
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default.*.id)
@@ -59,7 +59,7 @@ resource "aws_route" "requestor" {
 
 # Create routes from acceptor to requestor
 resource "aws_route" "acceptor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.acceptor.0.ids))) * length(data.aws_vpc.requestor.0.cidr_block_associations) : 0
+  count                     = module.this.enabled && var.acceptor_routes_create ? length(distinct(sort(data.aws_route_tables.acceptor.0.ids))) * length(data.aws_vpc.requestor.0.cidr_block_associations) : 0
   route_table_id            = element(distinct(sort(data.aws_route_tables.acceptor.0.ids)), ceil(count.index / length(data.aws_vpc.requestor.0.cidr_block_associations)))
   destination_cidr_block    = data.aws_vpc.requestor.0.cidr_block_associations[count.index % length(data.aws_vpc.requestor.0.cidr_block_associations)]["cidr_block"]
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default.*.id)

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "requestor_route_table_tags" {
   default     = {}
 }
 
+variable "requestor_routes_create" {
+  type        = bool
+  description = "Whether to add routes for the requestor VPC to the route tables or not"
+  default     = true
+}
+
 variable "acceptor_vpc_id" {
   type        = string
   description = "Acceptor VPC ID"
@@ -32,6 +38,12 @@ variable "acceptor_route_table_tags" {
   type        = map(string)
   description = "Only add peer routes to acceptor VPC route tables matching these tags"
   default     = {}
+}
+
+variable "acceptor_routes_create" {
+  type        = bool
+  description = "Whether to add routes for the acceptor VPC to the route tables or not"
+  default     = true
 }
 
 variable "auto_accept" {


### PR DESCRIPTION
## what
* With this feature, you will be able to specify whether create routes in the route table.

## why
* our company has the network policies which allow you only to create the peering connections, but the route part they want to control by hand. 


