### PR TITLE
Remove unused and deprecated `template` provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Available targets:
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 
@@ -327,7 +326,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2022 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,7 +6,6 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 1.3 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0 |
 
 ## Providers
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     local = {
       source  = "hashicorp/local"
       version = ">= 1.3"

--- a/versions.tf
+++ b/versions.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
     local = {
       source  = "hashicorp/local"
       version = ">= 1.3"


### PR DESCRIPTION
## what
* Removes the `template` provider from `required_providers`

## why
* The `template` provider is deprecated by Hashicorp.
* Said provider appears to be unused in this module (it works perfectly fine without it).
* Trying to run Terraform on an M1 Mac with this module results in an error since the `template` provider does not have a `darwin_arm64` build.

## references
* https://github.com/hashicorp/terraform-provider-template/issues/85
* https://github.com/hashicorp/terraform/issues/27257