### PR TITLE
Preserve AWS VPC Peering routes if they do not change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,20 +48,44 @@ data "aws_route_tables" "acceptor" {
   tags   = var.acceptor_route_table_tags
 }
 
+locals {
+  requestor_route_tables = module.this.enabled ? flatten([
+    for route_table_id in distinct(sort(data.aws_route_tables.requestor.0.ids)) : [
+      for cidr_block_association in data.aws_vpc.acceptor.0.cidr_block_associations : {
+        route_table_id = route_table_id
+        cidr_block     = cidr_block_association.cidr_block
+      }
+    ]
+  ]) : []
+
+  acceptor_route_tables = module.this.enabled ? flatten([
+    for route_table_id in distinct(sort(data.aws_route_tables.acceptor.0.ids)) : [
+      for cidr_block_association in data.aws_vpc.requestor.0.cidr_block_associations : {
+        route_table_id = route_table_id
+        cidr_block     = cidr_block_association.cidr_block
+      }
+    ]
+  ]) : []
+}
+
 # Create routes from requestor to acceptor
 resource "aws_route" "requestor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.requestor.0.ids))) * length(data.aws_vpc.acceptor.0.cidr_block_associations) : 0
-  route_table_id            = element(distinct(sort(data.aws_route_tables.requestor.0.ids)), ceil(count.index / length(data.aws_vpc.acceptor.0.cidr_block_associations)))
-  destination_cidr_block    = data.aws_vpc.acceptor.0.cidr_block_associations[count.index % length(data.aws_vpc.acceptor.0.cidr_block_associations)]["cidr_block"]
+  for_each = {
+    for value in local.requestor_route_tables : "${value.route_table_id}:${value.cidr_block}" => value
+  }
+  route_table_id            = each.value.route_table_id
+  destination_cidr_block    = each.value.cidr_block
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default.*.id)
   depends_on                = [data.aws_route_tables.requestor, aws_vpc_peering_connection.default]
 }
 
 # Create routes from acceptor to requestor
 resource "aws_route" "acceptor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.acceptor.0.ids))) * length(data.aws_vpc.requestor.0.cidr_block_associations) : 0
-  route_table_id            = element(distinct(sort(data.aws_route_tables.acceptor.0.ids)), ceil(count.index / length(data.aws_vpc.requestor.0.cidr_block_associations)))
-  destination_cidr_block    = data.aws_vpc.requestor.0.cidr_block_associations[count.index % length(data.aws_vpc.requestor.0.cidr_block_associations)]["cidr_block"]
+  for_each = {
+    for value in local.acceptor_route_tables : "${value.route_table_id}:${value.cidr_block}" => value
+  }
+  route_table_id            = each.value.route_table_id
+  destination_cidr_block    = each.value.cidr_block
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default.*.id)
   depends_on                = [data.aws_route_tables.acceptor, aws_vpc_peering_connection.default]
 }


### PR DESCRIPTION
Use a `for_each` of the cross-product of route_table_ids -> VPC CIDR blocks to generate stable names for the requestor and acceptor `aws_route` resources.

If the order of the route tables changes, it forces replacement of all route tables which can cause downtime during an apply.

⚠️ **Important** ⚠️ 

Switching from a `count` to `for_each` changes all of the `aws_route` resource names, which can cause downtime during an apply.  Callers will need to move the state of any existing `aws_route` resources to the new names to avoid any downtime.

We should consider bumping the minor version to indicate that this is somewhat of a breaking change.

For example, to move the state for the following `aws_route`:

```
  # module.vpc_peering.aws_route.requestor[0] will be destroyed
  # (because resource does not use count)
  - resource "aws_route" "requestor" {
      - destination_cidr_block    = "10.1.0.0/16" -> null
      - id                        = "r-rtb-xxxxyy" -> null
      - origin                    = "CreateRoute" -> null
      - route_table_id            = "rtb-xxxx" -> null
      - state                     = "active" -> null
      - vpc_peering_connection_id = "pcx-zzzz" -> null
    }
...
  # module.vpc_peering.aws_route.requestor["rtb-xxxx:10.1.0.0/16"] will be created
  + resource "aws_route" "requestor" {
      + destination_cidr_block    = "10.1.0.0/16"
      + id                        = (known after apply)
      + instance_id               = (known after apply)
      + instance_owner_id         = (known after apply)
      + network_interface_id      = (known after apply)
      + origin                    = (known after apply)
      + route_table_id            = "rtb-xxxx"
      + state                     = (known after apply)
      + vpc_peering_connection_id = "pcx-zzzz"
    }
```

Run the following command before the plan and apply:
```
terraform state mv module.vpc_peering.aws_route.requestor[0] module.vpc_peering.aws_route.requestor["rtb-xxxx:10.1.0.0/16"]
```

And `module.vpc_peering.aws_route.requestor["rtb-xxxx:10.1.0.0/16"]` should be unchanged.

closes #33 