### PR TITLE
Add/ignore cidr blocks

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -11,3 +11,5 @@ name = "vpc-peering"
 requestor_vpc_cidr = "172.16.0.0/16"
 
 acceptor_vpc_cidr = "172.32.0.0/16"
+
+requestor_additional_ipv4_cidr_block = "100.64.0.0/16"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,45 +3,65 @@ provider "aws" {
 }
 
 module "requestor_vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.1"
-  attributes = ["requestor"]
-  cidr_block = var.requestor_vpc_cidr
+  source                  = "cloudposse/vpc/aws"
+  version                 = "1.2.0"
+  attributes              = ["requestor"]
+  ipv4_primary_cidr_block = var.requestor_vpc_cidr
+  ipv4_additional_cidr_block_associations = {
+    ipv4_cidr_block     = var.requestor_additional_ipv4_cidr_block
+    ipv4_ipam_pool_id   = null
+    ipv4_netmask_length = null
+  }
 
   context = module.this.context
 }
 
 module "requestor_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.33.0"
+  version              = "2.0.4"
   availability_zones   = var.availability_zones
   attributes           = ["requestor"]
   vpc_id               = module.requestor_vpc.vpc_id
   igw_id               = module.requestor_vpc.igw_id
-  cidr_block           = module.requestor_vpc.vpc_cidr_block
+  ipv4_cidr_block      = module.requestor_vpc.vpc_cidr_block
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 
   context = module.this.context
 }
 
+module "requestor_subnets_additional" {
+  source                 = "cloudposse/dynamic-subnets/aws"
+  version                = "2.0.4"
+  availability_zones     = var.availability_zones
+  attributes             = ["requestor"]
+  vpc_id                 = module.requestor_vpc.vpc_id
+  igw_id                 = module.requestor_vpc.igw_id
+  ipv4_cidr_block        = var.requestor_additional_ipv4_cidr_block
+  nat_gateway_enabled    = false
+  nat_instance_enabled   = false
+  public_subnets_enabled = false
+
+  context = module.this.context
+}
+
 module "acceptor_vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.1"
-  attributes = ["acceptor"]
-  cidr_block = var.acceptor_vpc_cidr
+  source                  = "cloudposse/vpc/aws"
+  version                 = "1.2.0"
+  attributes              = ["acceptor"]
+  ipv4_primary_cidr_block = var.acceptor_vpc_cidr
 
   context = module.this.context
 }
 
 module "acceptor_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.33.0"
+  version              = "2.0.4"
   availability_zones   = var.availability_zones
   attributes           = ["acceptor"]
   vpc_id               = module.acceptor_vpc.vpc_id
   igw_id               = module.acceptor_vpc.igw_id
-  cidr_block           = module.acceptor_vpc.vpc_cidr_block
+  ipv4_cidr_block      = module.requestor_vpc.vpc_cidr_block
   nat_gateway_enabled  = false
   nat_instance_enabled = false
 
@@ -55,6 +75,7 @@ module "vpc_peering" {
   acceptor_allow_remote_vpc_dns_resolution  = true
   requestor_vpc_id                          = module.requestor_vpc.vpc_id
   acceptor_vpc_id                           = module.acceptor_vpc.vpc_id
+  requestor_ignore_cidrs                    = [var.requestor_additional_ipv4_cidr_block]
   create_timeout                            = "5m"
   update_timeout                            = "5m"
   delete_timeout                            = "10m"

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -3,7 +3,7 @@ output "requestor_vpc_cidr" {
   description = "Requestor VPC CIDR block"
 }
 
-output "requestor_vpc_additional_cidr" {
+output "requestor_vpc_additional_cidrs" {
   value       = module.requestor_vpc.vpc_cidr_block_associations
   description = "Requestor VPC additional CIDR block associations"
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,6 +1,11 @@
 output "requestor_vpc_cidr" {
   value       = module.requestor_vpc.vpc_cidr_block
-  description = "Requestor VPC ID"
+  description = "Requestor VPC CIDR block"
+}
+
+output "requestor_vpc_additional_cidr" {
+  value       = module.requestor_vpc.vpc_cidr_block_associations
+  description = "Requestor VPC additional CIDR block associations"
 }
 
 output "requestor_public_subnet_cidrs" {
@@ -11,6 +16,11 @@ output "requestor_public_subnet_cidrs" {
 output "requestor_private_subnet_cidrs" {
   value       = module.requestor_subnets.private_subnet_cidrs
   description = "Requestor private subnet CIDRs"
+}
+
+output "requestor_additional_subnet_cidrs" {
+  value       = module.requestor_subnets_additional.private_subnet_cidrs
+  description = "Requestor additional subnet CIDRs"
 }
 
 output "acceptor_vpc_cidr" {

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -17,3 +17,8 @@ variable "acceptor_vpc_cidr" {
   type        = string
   description = "Acceptor VPC CIDR"
 }
+
+variable "requestor_additional_ipv4_cidr_block" {
+  description = "An additional IPv4 CIDR block to associate with the VPC"
+  type        = string
+}

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -52,9 +52,9 @@ func TestExamplesComplete(t *testing.T) {
 	assert.Equal(t, "172.16.0.0/16", requestorVpcCidr)
 
 	// Run `terraform output` to get the value of an output variable
-	requestorVpcAdditionalCidr := terraform.Output(t, terraformOptions, "requestor_vpc_additional_cidr")
+	requestorVpcAdditionalCidrs := terraform.Output(t, terraformOptions, "requestor_vpc_additional_cidrs")
 	// Verify we're getting back the outputs we expect
-	assert.Equal(t, "100.64.0.0/16", requestorVpcAdditionalCidr)	
+	assert.Equal(t, []string{"100.64.0.0/16"}, requestorVpcAdditionalCidrs)	
 
 	// Run `terraform output` to get the value of an output variable
 	requestorPrivateSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_private_subnet_cidrs")

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -52,6 +52,11 @@ func TestExamplesComplete(t *testing.T) {
 	assert.Equal(t, "172.16.0.0/16", requestorVpcCidr)
 
 	// Run `terraform output` to get the value of an output variable
+	requestorVpcAdditionalCidr := terraform.Output(t, terraformOptions, "requestor_vpc_additional_cidr")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, "100.64.0.0/16", requestorVpcAdditionalCidr)	
+
+	// Run `terraform output` to get the value of an output variable
 	requestorPrivateSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_private_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, []string{"172.16.0.0/19", "172.16.32.0/19"}, requestorPrivateSubnetCidrs)
@@ -60,6 +65,11 @@ func TestExamplesComplete(t *testing.T) {
 	requestorPublicSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_public_subnet_cidrs")
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, []string{"172.16.96.0/19", "172.16.128.0/19"}, requestorPublicSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorAdditionalSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_additional_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"100.64.0.0/19", "100.64.32.0/19"}, requestorAdditionalSubnetCidrs)
 
 	// Run `terraform output` to get the value of an output variable
 	acceptorVpcCidr := terraform.Output(t, terraformOptions, "acceptor_vpc_cidr")

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,15 @@ variable "delete_timeout" {
   description = "VPC peering connection delete timeout. For more details, see https://www.terraform.io/docs/configuration/resources.html#operation-timeouts"
   default     = "5m"
 }
+
+variable "requestor_ignore_cidrs" {
+  type        = list(string)
+  description = "A list of CIDR blocks from the requestor VPC to ignore"
+  default     = []
+}
+
+variable "acceptor_ignore_cidrs" {
+  type        = list(string)
+  description = "A list of CIDR blocks from the acceptor VPC to ignore"
+  default     = []
+}


### PR DESCRIPTION
## what
* This PR will introduce logic to ignore certain CIDR ranges from either the requestor or acceptor VPC(s), without affecting the existing functionality. 

## why
* We add the CIDR range `100.64.0.0/16` to each of our EKS cluster VPCs to increase the maximum amount of assignable IP addresses when using the AWS VPC CNI.
* This causes issues when attempting to leverage this existing peering module, as the `100.64.0.0/16` routes will conflict in certain cases.
* One specific case is where we want to peer and route a single `database` or `elasticsearch` VPC to multiple different EKS cluster VPCs that all contain the `100.64.0.0/16` additional CIDR association

## references
* https://aws.amazon.com/premiumsupport/knowledge-center/eks-multiple-cidr-ranges/
