### PR TITLE
provision acceptor vpc in a different region

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -1,6 +1,10 @@
 region = "us-east-2"
 
+acceptor_region = "us-east-1"
+
 availability_zones = ["us-east-2a", "us-east-2b"]
+
+accceptor_availability_zones = ["us-east-1a", "us-east-1b"]
 
 namespace = "eg"
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,6 +2,11 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias = "us-east-1"
+  region = "us-east-2"
+}
+
 module "requestor_vpc" {
   source                  = "cloudposse/vpc/aws"
   version                 = "2.1.0"
@@ -51,6 +56,11 @@ module "requestor_subnets_additional" {
 }
 
 module "acceptor_vpc" {
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
   source                  = "cloudposse/vpc/aws"
   version                 = "2.1.0"
   attributes              = ["acceptor"]
@@ -60,6 +70,11 @@ module "acceptor_vpc" {
 }
 
 module "acceptor_subnets" {
+
+  providers = {
+    aws = aws.us-east-1
+  }
+
   source               = "cloudposse/dynamic-subnets/aws"
   version              = "2.1.0"
   availability_zones   = var.availability_zones

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 provider "aws" {
   alias = "us-east-1"
-  region = "us-east-2"
+  region = var.acceptor_region
 }
 
 module "requestor_vpc" {
@@ -77,7 +77,7 @@ module "acceptor_subnets" {
 
   source               = "cloudposse/dynamic-subnets/aws"
   version              = "2.1.0"
-  availability_zones   = var.availability_zones
+  availability_zones   = var.accceptor_availability_zones
   attributes           = ["acceptor"]
   vpc_id               = module.acceptor_vpc.vpc_id
   igw_id               = [module.acceptor_vpc.igw_id]

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -3,7 +3,17 @@ variable "region" {
   description = "AWS Region"
 }
 
+variable "acceptor_region" {
+  type        = string
+  description = "AWS Region"
+}
+
 variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones"
+}
+
+variable "accceptor_availability_zones" {
   type        = list(string)
   description = "List of availability zones"
 }


### PR DESCRIPTION
## what

Provision acceptor vpc in a different region to test cross region vpc-peering connection. 

## why
This is for use cases when both requestor and acceptor vpcs are in the same region, especially for privatelink over VPC connectivity option.
