### PR TITLE
remove unused hashicorp/local provider

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,4 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
-  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,4 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
+  }
 }


### PR DESCRIPTION
## what

- remove usage of hashicorp/local provider & update examples

## why

- the hashicorp/local provider is not in use
- the hashicorp/local provider can be used to load files from local machine, when not intended this functionality can cause security concerns 

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
