### PR TITLE
Support for applying without `-target`

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -88,6 +88,36 @@ usage: |2-
     }
   }
   ```
+
+  ### Specifying VPC CIDR blocks and Route Table IDs manually
+
+  Use this approach if you wish to deploy a VPC, Subnets, and a Peering connection without using `-target`.
+
+  ```hcl
+  module "vpc_peering" {
+    source = "cloudposse/vpc-peering/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
+    namespace                                 = "eg"
+    stage                                     = "dev"
+    name                                      = "cluster"
+    acceptor_vpc_id                           = "vpc-xxxxxxxxxxxxxxxxx"
+    requestor_vpc_id                          = "vpc-xxxxxxxxxxxxxxxxx"
+    acceptor_cidr_blocks                      = ["172.16.0.0/16"]
+    requestor_cidr_blocks                     = ["172.17.0.0/16"]
+    acceptor_route_table_ids = [
+      "rtb-xxxxxxxxxxxxxxxxx",
+      "rtb-yyyyyyyyyyyyyyyyy",
+      "rtb-xxxxxxxxxxxxxxxxx"
+    ]
+    requestor_cidr_blocks = [
+      "rtb-aaaaaaaaaaaaaaaaa",
+      "rtb-bbbbbbbbbbbbbbbbb",
+      "rtb-ccccccccccccccccc"
+    ]
+  }
+  ```
+
 references:
   - name: "terraform-aws-vpc-kops-peering"
     description: "Thanks to [Gladly.com](https://www.gladly.com/) for the inspiration with this wonderful module"

--- a/README.yaml
+++ b/README.yaml
@@ -102,7 +102,7 @@ usage: |2-
     stage                                     = "dev"
     name                                      = "cluster"
     acceptor_vpc_id                           = "vpc-xxxxxxxxxxxxxxxxx"
-    requestor_vpc_id                          = "vpc-xxxxxxxxxxxxxxxxx"
+    requestor_vpc_id                          = "vpc-yyyyyyyyyyyyyyyyy"
     acceptor_cidr_blocks                      = ["172.16.0.0/16"]
     requestor_cidr_blocks                     = ["172.17.0.0/16"]
     acceptor_route_table_ids = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "requestor_vpc" {
   source                  = "cloudposse/vpc/aws"
-  version                 = "2.1.0"
+  version                 = "2.3.0"
   attributes              = ["requestor"]
   ipv4_primary_cidr_block = var.requestor_vpc_cidr
   ipv4_additional_cidr_block_associations = {
@@ -20,7 +20,7 @@ module "requestor_vpc" {
 
 module "requestor_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "2.3.0"
+  version              = "2.4.2"
   availability_zones   = var.availability_zones
   attributes           = ["requestor"]
   vpc_id               = module.requestor_vpc.vpc_id
@@ -34,7 +34,7 @@ module "requestor_subnets" {
 
 module "requestor_subnets_additional" {
   source                 = "cloudposse/dynamic-subnets/aws"
-  version                = "2.3.0"
+  version                = "2.4.2"
   availability_zones     = var.availability_zones
   attributes             = ["requestor"]
   vpc_id                 = module.requestor_vpc.vpc_id
@@ -52,7 +52,7 @@ module "requestor_subnets_additional" {
 
 module "acceptor_vpc" {
   source                  = "cloudposse/vpc/aws"
-  version                 = "2.1.0"
+  version                 = "2.3.0"
   attributes              = ["acceptor"]
   ipv4_primary_cidr_block = var.acceptor_vpc_cidr
 
@@ -61,7 +61,7 @@ module "acceptor_vpc" {
 
 module "acceptor_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "2.1.0"
+  version              = "2.4.2"
   availability_zones   = var.availability_zones
   attributes           = ["acceptor"]
   vpc_id               = module.acceptor_vpc.vpc_id

--- a/examples/single_apply/context.tf
+++ b/examples/single_apply/context.tf
@@ -1,0 +1,279 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# curl -sL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf -o context.tf
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.25.0" # requires Terraform >= 0.13.0
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  tenant              = var.tenant
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+  label_key_case      = var.label_key_case
+  label_value_case    = var.label_value_case
+  descriptor_formats  = var.descriptor_formats
+  labels_as_tags      = var.labels_as_tags
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = any
+  default = {
+    enabled             = true
+    namespace           = null
+    tenant              = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+    label_key_case      = null
+    label_value_case    = null
+    descriptor_formats  = {}
+    # Note: we have to use [] instead of null for unset lists due to
+    # https://github.com/hashicorp/terraform/issues/28137
+    # which was not fixed until Terraform 1.0.0,
+    # but we want the default to be all the labels in `label_order`
+    # and we want users to be able to prevent all tag generation
+    # by setting `labels_as_tags` to `[]`, so we need
+    # a different sentinel to indicate "default"
+    labels_as_tags = ["unset"]
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+
+  validation {
+    condition     = lookup(var.context, "label_key_case", null) == null ? true : contains(["lower", "title", "upper"], var.context["label_key_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+
+  validation {
+    condition     = lookup(var.context, "label_value_case", null) == null ? true : contains(["lower", "title", "upper", "none"], var.context["label_value_case"])
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique"
+}
+
+variable "tenant" {
+  type        = string
+  default     = null
+  description = "ID element _(Rarely used, not included by default)_. A customer identifier, indicating who this instance of a resource is for"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used for region e.g. 'uw2', 'us-west-2', OR role 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    ID element. Usually the component or solution name, e.g. 'app' or 'jenkins'.
+    This is the only ID element not also included as a `tag`.
+    The "name" tag is set to the full `id` string. There is no tag with the value of the `name` input.
+    EOT
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between ID elements.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = <<-EOT
+    ID element. Additional attributes (e.g. `workers` or `cluster`) to add to `id`,
+    in the order they appear in the list. New attributes are appended to the
+    end of the list. The elements of the list are joined by the `delimiter`
+    and treated as a single ID element.
+    EOT
+}
+
+variable "labels_as_tags" {
+  type        = set(string)
+  default     = ["default"]
+  description = <<-EOT
+    Set of labels (ID elements) to include as tags in the `tags` output.
+    Default is to include all labels.
+    Tags with empty values will not be included in the `tags` output.
+    Set to `[]` to suppress all generated tags.
+    **Notes:**
+      The value of the `name` tag, if included, will be the `id`, not the `name`.
+      Unlike other `null-label` inputs, the initial setting of `labels_as_tags` cannot be
+      changed in later chained modules. Attempts to change it will be silently ignored.
+    EOT
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).
+    Neither the tag keys nor the tag values will be modified by this module.
+    EOT
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = <<-EOT
+    Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.
+    This is for some rare cases where resources want additional configuration of tags
+    and therefore take a list of maps with tag key, value, and additional configuration.
+    EOT
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The order in which the labels (ID elements) appear in the `id`.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 6 labels ("tenant" is the 6th), but at least one must be present.
+    EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Terraform regular expression (regex) string.
+    Characters matching the regex will be removed from the ID elements.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters (minimum 6).
+    Set to `0` for unlimited length.
+    Set to `null` for keep the existing setting, which defaults to `0`.
+    Does not affect `id_full`.
+  EOT
+  validation {
+    condition     = var.id_length_limit == null ? true : var.id_length_limit >= 6 || var.id_length_limit == 0
+    error_message = "The id_length_limit must be >= 6 if supplied (not null), or 0 for unlimited length."
+  }
+}
+
+variable "label_key_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of the `tags` keys (label names) for tags generated by this module.
+    Does not affect keys of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper`.
+    Default value: `title`.
+  EOT
+
+  validation {
+    condition     = var.label_key_case == null ? true : contains(["lower", "title", "upper"], var.label_key_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`."
+  }
+}
+
+variable "label_value_case" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Controls the letter case of ID elements (labels) as included in `id`,
+    set as tag values, and output by this module individually.
+    Does not affect values of tags passed in via the `tags` input.
+    Possible values: `lower`, `title`, `upper` and `none` (no transformation).
+    Set this to `title` and set `delimiter` to `""` to yield Pascal Case IDs.
+    Default value: `lower`.
+  EOT
+
+  validation {
+    condition     = var.label_value_case == null ? true : contains(["lower", "title", "upper", "none"], var.label_value_case)
+    error_message = "Allowed values: `lower`, `title`, `upper`, `none`."
+  }
+}
+
+variable "descriptor_formats" {
+  type        = any
+  default     = {}
+  description = <<-EOT
+    Describe additional descriptors to be output in the `descriptors` output map.
+    Map of maps. Keys are names of descriptors. Values are maps of the form
+    `{
+       format = string
+       labels = list(string)
+    }`
+    (Type is `any` so the map values can later be enhanced to provide additional options.)
+    `format` is a Terraform format string to be passed to the `format()` function.
+    `labels` is a list of labels, in order, to pass to `format()` function.
+    Label values will be normalized before being passed to `format()` so they will be
+    identical to how they appear in `id`.
+    Default is `{}` (`descriptors` output will be empty).
+    EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/single_apply/fixtures.us-east-2.tfvars
+++ b/examples/single_apply/fixtures.us-east-2.tfvars
@@ -1,0 +1,15 @@
+region = "us-east-2"
+
+availability_zones = ["us-east-2a", "us-east-2b"]
+
+namespace = "eg"
+
+stage = "test"
+
+name = "vpc-peering"
+
+requestor_vpc_cidr = "172.16.0.0/16"
+
+acceptor_vpc_cidr = "172.32.0.0/16"
+
+requestor_additional_ipv4_cidr_block = "100.64.0.0/16"

--- a/examples/single_apply/main.tf
+++ b/examples/single_apply/main.tf
@@ -1,0 +1,100 @@
+provider "aws" {
+  region = var.region
+}
+
+module "requestor_vpc" {
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.3.0"
+  attributes              = ["requestor"]
+  ipv4_primary_cidr_block = var.requestor_vpc_cidr
+  ipv4_additional_cidr_block_associations = {
+    (var.requestor_additional_ipv4_cidr_block) = {
+      ipv4_cidr_block     = var.requestor_additional_ipv4_cidr_block
+      ipv4_ipam_pool_id   = null
+      ipv4_netmask_length = null
+    }
+  }
+
+  context = module.this.context
+}
+
+module "requestor_subnets" {
+  source              = "cloudposse/dynamic-subnets/aws"
+  version             = "2.4.2"
+  availability_zones  = var.availability_zones
+  attributes          = ["requestor"]
+  vpc_id              = module.requestor_vpc.vpc_id
+  igw_id              = [module.requestor_vpc.igw_id]
+  ipv4_cidr_block     = [module.requestor_vpc.vpc_cidr_block]
+  nat_gateway_enabled = false
+
+  context = module.this.context
+}
+
+module "requestor_subnets_additional" {
+  source                 = "cloudposse/dynamic-subnets/aws"
+  version                = "2.4.2"
+  availability_zones     = var.availability_zones
+  attributes             = ["requestor"]
+  vpc_id                 = module.requestor_vpc.vpc_id
+  igw_id                 = [module.requestor_vpc.igw_id]
+  ipv4_cidr_block        = [var.requestor_additional_ipv4_cidr_block]
+  nat_gateway_enabled    = false
+  public_subnets_enabled = false
+
+  context = module.this.context
+
+  # necessary for clean destory, see open issue: https://github.com/hashicorp/terraform-provider-aws/issues/9592
+  depends_on = [module.requestor_vpc]
+}
+
+module "acceptor_vpc" {
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.3.0"
+  attributes              = ["acceptor"]
+  ipv4_primary_cidr_block = var.acceptor_vpc_cidr
+
+  context = module.this.context
+}
+
+module "acceptor_subnets" {
+  source              = "cloudposse/dynamic-subnets/aws"
+  version             = "2.4.2"
+  availability_zones  = var.availability_zones
+  attributes          = ["acceptor"]
+  vpc_id              = module.acceptor_vpc.vpc_id
+  igw_id              = [module.acceptor_vpc.igw_id]
+  ipv4_cidr_block     = [module.acceptor_vpc.vpc_cidr_block]
+  nat_gateway_enabled = false
+
+  context = module.this.context
+}
+
+module "vpc_peering" {
+  source                                    = "../.."
+  auto_accept                               = true
+  requestor_allow_remote_vpc_dns_resolution = true
+  acceptor_allow_remote_vpc_dns_resolution  = true
+  acceptor_cidr_blocks                      = [var.acceptor_vpc_cidr]
+  acceptor_route_table_ids = concat(
+    module.acceptor_subnets.private_route_table_ids,
+    module.acceptor_subnets.public_route_table_ids,
+    [module.acceptor_vpc.vpc_default_route_table_id]
+  )
+  acceptor_vpc_id       = module.acceptor_vpc.vpc_id
+  requestor_cidr_blocks = [var.requestor_vpc_cidr, var.requestor_additional_ipv4_cidr_block]
+  requestor_route_table_ids = concat(
+    module.requestor_subnets.private_route_table_ids,
+    module.requestor_subnets_additional.private_route_table_ids,
+    module.requestor_subnets.public_route_table_ids,
+    module.requestor_subnets_additional.public_route_table_ids,
+    [module.requestor_vpc.vpc_default_route_table_id]
+  )
+  requestor_ignore_cidrs = [var.requestor_additional_ipv4_cidr_block]
+  requestor_vpc_id       = module.requestor_vpc.vpc_id
+  create_timeout         = "5m"
+  update_timeout         = "5m"
+  delete_timeout         = "10m"
+
+  context = module.this.context
+}

--- a/examples/single_apply/outputs.tf
+++ b/examples/single_apply/outputs.tf
@@ -1,0 +1,49 @@
+output "requestor_vpc_cidr" {
+  value       = module.requestor_vpc.vpc_cidr_block
+  description = "Requestor VPC CIDR block"
+}
+
+output "requestor_vpc_additional_cidrs" {
+  value       = module.requestor_vpc.additional_cidr_blocks
+  description = "Requestor VPC additional CIDR block associations"
+}
+
+output "requestor_public_subnet_cidrs" {
+  value       = module.requestor_subnets.public_subnet_cidrs
+  description = "Requestor public subnet CIDRs"
+}
+
+output "requestor_private_subnet_cidrs" {
+  value       = module.requestor_subnets.private_subnet_cidrs
+  description = "Requestor private subnet CIDRs"
+}
+
+output "requestor_additional_subnet_cidrs" {
+  value       = module.requestor_subnets_additional.private_subnet_cidrs
+  description = "Requestor additional subnet CIDRs"
+}
+
+output "acceptor_vpc_cidr" {
+  value       = module.acceptor_vpc.vpc_cidr_block
+  description = "Acceptor VPC ID"
+}
+
+output "acceptor_public_subnet_cidrs" {
+  value       = module.acceptor_subnets.public_subnet_cidrs
+  description = "Acceptor public subnet CIDRs"
+}
+
+output "acceptor_private_subnet_cidrs" {
+  value       = module.acceptor_subnets.private_subnet_cidrs
+  description = "Acceptor private subnet CIDRs"
+}
+
+output "connection_id" {
+  value       = module.vpc_peering.connection_id
+  description = "VPC peering connection ID"
+}
+
+output "accept_status" {
+  value       = module.vpc_peering.accept_status
+  description = "The status of the VPC peering connection request"
+}

--- a/examples/single_apply/variables.tf
+++ b/examples/single_apply/variables.tf
@@ -1,0 +1,24 @@
+variable "region" {
+  type        = string
+  description = "AWS Region"
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones"
+}
+
+variable "requestor_vpc_cidr" {
+  type        = string
+  description = "Requestor VPC CIDR"
+}
+
+variable "acceptor_vpc_cidr" {
+  type        = string
+  description = "Acceptor VPC CIDR"
+}
+
+variable "requestor_additional_ipv4_cidr_block" {
+  description = "An additional IPv4 CIDR block to associate with the VPC"
+  type        = string
+}

--- a/examples/single_apply/versions.tf
+++ b/examples/single_apply/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -37,40 +37,64 @@ data "aws_vpc" "acceptor" {
 }
 
 data "aws_route_tables" "requestor" {
-  count  = module.this.enabled ? 1 : 0
+  count  = module.this.enabled && length(var.requestor_route_table_ids) == 0 ? 1 : 0
   vpc_id = join("", data.aws_vpc.requestor[*].id)
   tags   = var.requestor_route_table_tags
 }
 
 data "aws_route_tables" "acceptor" {
-  count  = module.this.enabled ? 1 : 0
+  count  = module.this.enabled && length(var.acceptor_route_table_ids) == 0 ? 1 : 0
   vpc_id = join("", data.aws_vpc.acceptor[*].id)
   tags   = var.acceptor_route_table_tags
 }
 
 locals {
-  requestor_cidr_blocks = module.this.enabled ? tolist(setsubtract([
-    for k, v in data.aws_vpc.requestor[0].cidr_block_associations : v.cidr_block
-  ], var.requestor_ignore_cidrs)) : []
-  acceptor_cidr_blocks = module.this.enabled ? tolist(setsubtract([
-    for k, v in data.aws_vpc.acceptor[0].cidr_block_associations : v.cidr_block
-  ], var.acceptor_ignore_cidrs)) : []
+  # List of CIDR blocks for the requestor VPC, excluding any ignored CIDRs
+  requestor_cidr_blocks = module.this.enabled ? (
+    length(var.requestor_cidr_blocks) == 0 ? (
+      tolist(setsubtract(data.aws_vpc.requestor[0].cidr_block_associations[*].cidr_block, var.requestor_ignore_cidrs))
+    ) : tolist(setsubtract(var.requestor_cidr_blocks, var.requestor_ignore_cidrs))
+  ) : []
+
+  # List of route table IDs for the requestor VPC, either discovered or provided
+  requestor_route_table_ids = module.this.enabled ? (
+    length(var.requestor_route_table_ids) == 0 ? distinct(data.aws_route_tables.requestor[0].ids) : var.requestor_route_table_ids
+  ) : []
+
+
+  # List of CIDR blocks for the acceptor VPC, excluding any ignored CIDRs
+  acceptor_cidr_blocks = module.this.enabled ? (
+    length(var.acceptor_cidr_blocks) == 0 ? (
+      tolist(setsubtract(data.aws_vpc.acceptor[0].cidr_block_associations[*].cidr_block, var.acceptor_ignore_cidrs))
+    ) : tolist(setsubtract(var.acceptor_cidr_blocks, var.acceptor_ignore_cidrs))
+  ) : []
+
+  # List of route table IDs for the acceptor VPC, either discovered or provided
+  acceptor_route_table_ids = module.this.enabled ? (
+    length(var.acceptor_route_table_ids) == 0 ? distinct(data.aws_route_tables.acceptor[0].ids) : var.acceptor_route_table_ids
+  ) : []
+
+  # Cartesian product of route table IDs and CIDR blocks for both requestor and acceptor
+  requestor_route_cidr_mapper = module.this.enabled ? tolist(setproduct(local.requestor_route_table_ids, local.acceptor_cidr_blocks)) : []
+  acceptor_route_cidr_mapper  = module.this.enabled ? tolist(setproduct(local.acceptor_route_table_ids, local.requestor_cidr_blocks)) : []
 }
 
 # Create routes from requestor to acceptor
 resource "aws_route" "requestor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.requestor[0].ids))) * length(local.acceptor_cidr_blocks) : 0
-  route_table_id            = element(distinct(sort(data.aws_route_tables.requestor[0].ids)), ceil(count.index / length(local.acceptor_cidr_blocks)))
-  destination_cidr_block    = local.acceptor_cidr_blocks[count.index % length(local.acceptor_cidr_blocks)]
+  # Using count instead of for_each to maintain compatibility with previous versions
+  count                     = length(local.requestor_route_cidr_mapper)
+  route_table_id            = local.requestor_route_cidr_mapper[count.index][0]
+  destination_cidr_block    = local.requestor_route_cidr_mapper[count.index][1]
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default[*].id)
   depends_on                = [data.aws_route_tables.requestor, aws_vpc_peering_connection.default]
 }
 
 # Create routes from acceptor to requestor
 resource "aws_route" "acceptor" {
-  count                     = module.this.enabled ? length(distinct(sort(data.aws_route_tables.acceptor[0].ids))) * length(local.requestor_cidr_blocks) : 0
-  route_table_id            = element(distinct(sort(data.aws_route_tables.acceptor[0].ids)), ceil(count.index / length(local.requestor_cidr_blocks)))
-  destination_cidr_block    = local.requestor_cidr_blocks[count.index % length(local.requestor_cidr_blocks)]
+  # Using count instead of for_each to maintain compatibility with previous versions
+  count                     = length(local.acceptor_route_cidr_mapper)
+  route_table_id            = local.acceptor_route_cidr_mapper[count.index][0]
+  destination_cidr_block    = local.acceptor_route_cidr_mapper[count.index][1]
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.default[*].id)
   depends_on                = [data.aws_route_tables.acceptor, aws_vpc_peering_connection.default]
 }

--- a/test/src/single_apply_test.go
+++ b/test/src/single_apply_test.go
@@ -1,0 +1,90 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test the Terraform module in examples/single_apply using Terratest.
+func TestSingleApply(t *testing.T) {
+	t.Parallel()
+
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/single_apply/",
+		Upgrade:      true,
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"fixtures.us-east-2.tfvars"},
+	}
+
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer func() {
+		if r := recover(); r != nil {
+			terraform.Destroy(t, terraformOptions)
+			assert.Fail(t, fmt.Sprintf("Panicked: %v", r))
+		} else {
+			terraform.Destroy(t, terraformOptions)
+		}
+	}()
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+
+	terraformOptions.Targets = nil
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.Apply(t, terraformOptions)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorVpcCidr := terraform.Output(t, terraformOptions, "requestor_vpc_cidr")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, "172.16.0.0/16", requestorVpcCidr)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorVpcAdditionalCidrs := terraform.OutputList(t, terraformOptions, "requestor_vpc_additional_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"100.64.0.0/16"}, requestorVpcAdditionalCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorPrivateSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_private_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"172.16.0.0/19", "172.16.32.0/19"}, requestorPrivateSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorPublicSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_public_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"172.16.96.0/19", "172.16.128.0/19"}, requestorPublicSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	requestorAdditionalSubnetCidrs := terraform.OutputList(t, terraformOptions, "requestor_additional_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"100.64.0.0/18", "100.64.64.0/18"}, requestorAdditionalSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	acceptorVpcCidr := terraform.Output(t, terraformOptions, "acceptor_vpc_cidr")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, "172.32.0.0/16", acceptorVpcCidr)
+
+	// Run `terraform output` to get the value of an output variable
+	acceptorPrivateSubnetCidrs := terraform.OutputList(t, terraformOptions, "acceptor_private_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"172.32.0.0/19", "172.32.32.0/19"}, acceptorPrivateSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	acceptorPublicSubnetCidrs := terraform.OutputList(t, terraformOptions, "acceptor_public_subnet_cidrs")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, []string{"172.32.96.0/19", "172.32.128.0/19"}, acceptorPublicSubnetCidrs)
+
+	// Run `terraform output` to get the value of an output variable
+	connectionId := terraform.Output(t, terraformOptions, "connection_id")
+	// Verify we're getting back the outputs we expect
+	assert.Contains(t, connectionId, "pcx-")
+
+	// Run `terraform output` to get the value of an output variable
+	acceptStatus := terraform.Output(t, terraformOptions, "accept_status")
+	// Verify we're getting back the outputs we expect
+	assert.Equal(t, "active", acceptStatus)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -81,3 +81,27 @@ variable "acceptor_ignore_cidrs" {
   description = "A list of CIDR blocks from the acceptor VPC to ignore"
   default     = []
 }
+
+variable "requestor_cidr_blocks" {
+  type        = list(string)
+  description = "Optional list of CIDR blocks from the requestor VPC to use for route creation. If empty, all CIDR blocks associated with the VPC will be used, except those in requestor_ignore_cidrs."
+  default     = []
+}
+
+variable "requestor_route_table_ids" {
+  type        = list(string)
+  description = "Optional list of requestor VPC route table IDs to add routes to. If empty, all route tables matching requestor_route_table_tags will be used."
+  default     = []
+}
+
+variable "acceptor_cidr_blocks" {
+  type        = list(string)
+  description = "Optional list of CIDR blocks from the acceptor VPC to use for route creation. If empty, all CIDR blocks associated with the VPC will be used, except those in acceptor_ignore_cidrs."
+  default     = []
+}
+
+variable "acceptor_route_table_ids" {
+  type        = list(string)
+  description = "Optional list of acceptor VPC route table IDs to add routes to. If empty, all route tables matching acceptor_route_table_tags will be used."
+  default     = []
+}


### PR DESCRIPTION
## what
This pull request introduces the ability to deploy a new VPC, subnets, and a peering connection without needing to use `-target`. It achieves this by adding variables for the manual specification of VPC CIDR blocks and route table IDs.

This should be backwards compatible with versions greater than `1.0.0` of this module. 

- Added additional vars for VPC CIDR blocks.
- Added additional vars for route table IDs.
- Enhanced logic for creating routes.
- Added a new test that demonstrates creating a VPC, subnets, and a peering connection in one `terraform apply`.
- Added documentation for the single-apply approach.

## why
- Closes #50 
- Closes #19